### PR TITLE
strip white space when specify a template in content file

### DIFF
--- a/liquidluck/writers/core.py
+++ b/liquidluck/writers/core.py
@@ -37,7 +37,7 @@ class PageWriter(BaseWriter):
     def start(self):
         l = len(g.source_directory) + 1
         for post in g.pure_pages:
-            template = post.template or self._template
+            template = post.template.strip() if post.template else self._template
             filename = os.path.splitext(post.filepath[l:])[0] + '.html'
             dest = os.path.join(g.output_directory, filename)
             self.render({'post': post}, template, dest)


### PR DESCRIPTION
when specify a template in content file. adding an extray space aftter the template filename. will course an error when build site.
- template: note.html  <- space here.

change one line to strip the space of template to fix this issue
