### PR TITLE
use same src for Python 2 and 3

### DIFF
--- a/liquidluck/cli.py
+++ b/liquidluck/cli.py
@@ -10,6 +10,9 @@ from liquidluck.options import enable_pretty_logging
 from liquidluck.options import g, settings
 from docopt import docopt
 
+if sys.version_info[:2] >= (3, 3):
+    raw_input = input
+
 documentation = {}
 documentation['help'] = """Felix Felicis %(version)s
 

--- a/liquidluck/filters.py
+++ b/liquidluck/filters.py
@@ -52,7 +52,7 @@ def content_url(ctx, base, *args):
         prefix = '/'
         args.insert(0, base)
 
-    args = map(lambda o: to_unicode(o).strip('/'), args)
+    args = [to_unicode(o).strip('/') for o in args]
     url = '/'.join(args).replace('//', '/').replace(' ', '-')
     url = prefix + url.lstrip('/')
     url = to_unicode(fix_index(url.lower()))

--- a/liquidluck/generator.py
+++ b/liquidluck/generator.py
@@ -9,6 +9,9 @@ from liquidluck.options import g, settings
 from liquidluck.utils import import_object, walk_dir, parse_settings
 from liquidluck.writers.base import load_jinja, find_theme
 
+if sys.version_info[:2] >= (3, 3):
+    raw_input = input
+
 
 def create_settings(filepath):
     if not filepath:

--- a/liquidluck/options.py
+++ b/liquidluck/options.py
@@ -6,6 +6,8 @@ import logging.handlers
 import sys
 import time
 
+if sys.version_info[:2] >= (3, 3):
+    unicode = str
 
 # For pretty log messages, if available
 try:

--- a/liquidluck/readers/base.py
+++ b/liquidluck/readers/base.py
@@ -7,12 +7,16 @@ Reader, read content, parse to html.
 :license: BSD
 '''
 
+import sys
 import os
 import logging
 import datetime
 import re
 from liquidluck.options import settings, g
 from liquidluck.utils import to_datetime, import_object
+
+if sys.version_info[:2] >= (3, 3):
+    basestring = str
 
 
 class BaseReader(object):

--- a/liquidluck/readers/markdown.py
+++ b/liquidluck/readers/markdown.py
@@ -41,6 +41,9 @@ from liquidluck.readers.base import BaseReader
 from liquidluck.options import settings
 from liquidluck.utils import to_unicode, cjk_nowrap, import_object
 
+if sys.version_info[:2] >= (3, 3):
+    basestring = str
+
 
 class MarkdownReader(BaseReader):
     SUPPORT_TYPE = ['md', 'mkd', 'markdown']

--- a/liquidluck/readers/restructuredtext.py
+++ b/liquidluck/readers/restructuredtext.py
@@ -129,7 +129,7 @@ class Pygments(Directive):
             lexer = TextLexer()
         # take an arbitrary option if more than one is given
 
-        formatter = self.options and VARIANTS[self.options.keys()[0]] \
+        formatter = self.options and VARIANTS[list(self.options.keys())[0]] \
                 or DEFAULT
         parsed = highlight('\n'.join(self.content), lexer, formatter)
         return [nodes.raw('', parsed, format='html')]

--- a/liquidluck/tools/server.py
+++ b/liquidluck/tools/server.py
@@ -83,6 +83,8 @@ def _read(abspath):
         return None
 
     f = open(filepath)
+    if filepath.endswith('.png'):
+        return None
     content = f.read()
     f.close()
     return content

--- a/liquidluck/tools/theme.py
+++ b/liquidluck/tools/theme.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import os
 from liquidluck.options import g
 from liquidluck.utils import to_unicode, utf8
@@ -32,7 +33,7 @@ def __filter_themes(content):
     repos = json_decode(content)
     themes = {}
     if 'repositories' not in repos and 'message' in repos:
-        print repos['message']
+        print(repos['message'])
         return {}
     for theme in repos['repositories']:
         fork = theme['fork']

--- a/liquidluck/tools/webhook.py
+++ b/liquidluck/tools/webhook.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import os
 import time
@@ -145,13 +146,13 @@ class Daemon(object):
             while 1:
                 os.kill(pid, SIGTERM)
                 time.sleep(0.1)
-        except OSError, err:
+        except OSError as err:
             err = str(err)
             if err.find("No such process") > 0:
                 if os.path.exists(self.pidfile):
                     os.remove(self.pidfile)
                 else:
-                    print str(err)
+                    print(str(err))
                     sys.exit(1)
 
     def restart(self):

--- a/liquidluck/utils.py
+++ b/liquidluck/utils.py
@@ -1,10 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import re
 import os
 import shutil
 import datetime
+import sys
+
+import six
+
+PY3 = False
+if sys.version_info[:2] >= (3, 3):
+    PY3 = True
+    unicode = str
+    basestring = str
 
 
 def to_unicode(value):
@@ -92,7 +103,7 @@ class UnicodeDict(dict):
 def cjk_nowrap(text):
     start = u'\u4e00'
     end = u'\u9fff'
-    pattern = ur'([%s-%s]+?)' % (start, end)
+    pattern = r'([%s-%s]+?)' % (start, end)
     cjk = re.compile(pattern + r'(\n|\r\n|\r)' + pattern)
     text = cjk.sub(r'\1\3', text)
     return text
@@ -122,7 +133,7 @@ def to_datetime(value):
 
 
 def get_relative_base(path):
-    length = len(filter(lambda o: o, path.split(os.path.sep)))
+    length = len([o for o in path.split(os.path.sep) if o])
     if length > 1:
         return '/'.join(['..' for i in range(length - 1)])
     return '.'
@@ -138,7 +149,10 @@ def parse_settings(path, filetype=None):
 
     def parse_py_settings(path):
         config = {}
-        execfile(path, {}, config)
+        if PY3:
+            six.exec_(compile(open(path).read(), path, 'exec'), {}, config)
+        else:
+            execfile(path, {}, config)
         return config
 
     def parse_yaml_settings(path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Pygments
 misaka
 docopt
 PyYAML
+six

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import sys
-kwargs = {}
-major, minor = sys.version_info[:2]
-if major >= 3:
-    kwargs['use_2to3'] = True
 
 from setuptools import setup
 install_requires = [
-    'Jinja2', 'Pygments', 'misaka', 'docopt', 'PyYAML', 'docutils'
+    'Jinja2', 'Pygments', 'misaka', 'docopt', 'PyYAML', 'docutils', 'six',
 ]
 
 
@@ -48,5 +44,4 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Text Processing :: Markup',
     ],
-    **kwargs
 )

--- a/tests/test_writers_base.py
+++ b/tests/test_writers_base.py
@@ -12,13 +12,13 @@ ROOT = os.path.abspath(os.path.dirname(__file__))
 
 class TestPagination(object):
     def test_pages(self):
-        p = Pagination(range(6), 1, 3)
+        p = Pagination(list(range(6)), 1, 3)
         assert p.pages == 2
 
-        p = Pagination(range(5), 1, 3)
+        p = Pagination(list(range(5)), 1, 3)
         assert p.pages == 2
 
-        p = Pagination(range(7), 1, 3)
+        p = Pagination(list(range(7)), 1, 3)
         assert p.pages == 3
 
     def test_items(self):


### PR DESCRIPTION
This is work is nearly complete. It works well on Python 3.3, but not 2.7. I get the following, which also results in empty output:

```
$ liquidluck server
[I 130418 21:27:34 generator:91] Load Settings Finished
[E 130418 21:19:33 base:75] 'unicode' object is not callable
...snip same repeated message
[E 130418 21:19:33 base:75] 'unicode' object is not callable
[I 130418 21:19:33 generator:138] Load Posts Finished
[I 130418 21:19:33 base:54] PostWriter Finished
[I 130418 21:19:33 base:54] PageWriter Finished
[I 130418 21:19:33 base:54] ArchiveWriter Finished
[I 130418 21:19:33 base:54] ArchiveFeedWriter Finished
[I 130418 21:19:33 base:54] FileWriter Finished
[I 130418 21:19:33 base:54] StaticWriter Finished
[I 130418 21:19:33 base:54] YearWriter Finished
[I 130418 21:19:33 base:54] CategoryWriter Finished
[I 130418 21:19:33 base:54] CategoryFeedWriter Finished
[I 130418 21:19:33 base:54] TagWriter Finished
[I 130418 21:19:33 base:54] TagCloudWriter Finished
[I 130418 21:19:33 server:309] Theme directory: /home/tshepang/projects/liquidluck/liquidluck/_themes/default
[I 130418 21:19:33 server:318] Start server at 127.0.0.1:8000
```
