### PR TITLE
Pin the hoedown version to fix the Travis tests and tidy up the supported Pythons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
 language: python
-python:
-    - 2.6
-    - 2.7
-    - 3.3
-    - 3.4
+
+matrix:
+  include:
+    - python: "2.6"
+      env: TOXENV=py26
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.3"
+      env: TOXENV=py33
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
 
 install:
-    - pip install docutils
-    - python setup.py install
+  - pip install -U pip setuptools
+  - pip install -U tox
 
 script:
-    - cd tests
-    - nosetests
+  - tox

--- a/README.rst
+++ b/README.rst
@@ -122,8 +122,9 @@ Compatibility
 
   - 2.6
   - 2.7
-  - 3.1
-  - 3.2
+  - 3.3
+  - 3.4
+  - 3.5
 
 
 .. _restructedText: http://docutils.sourceforge.net/rst.html

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Text Processing :: Markup',
     ],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if major >= 3:
     kwargs['use_2to3'] = True
 
 install_requires = [
-    'Jinja2', 'Pygments', 'hoedown', 'docopt', 'PyYAML', 'docutils'
+    'Jinja2', 'Pygments', 'hoedown<=0.2', 'docopt', 'PyYAML', 'docutils'
 ]
 
 author, author_email = parseaddr(liquidluck.__author__)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py31, py32
+envlist = py26, py27, py33, py34, py35
 
 [testenv]
 commands = nosetests -w tests


### PR DESCRIPTION
This resolves a couple of test-related issues:

* Pin the version of hoedown – this is what caused the failures in #122.
* Have Travis CI run the same set of supported versions as in tox.ini, in line with #115, and update the README to reflect the new version. Throw in Python&nbsp;3.5 support while we’re there, as it passes all the tests without changes.
* Have Travis call tox, rather than duplicating the logic for running tests in two different files.